### PR TITLE
[JSON Serialization]Support Default Value

### DIFF
--- a/Sources/SwiftProtobuf/JSONEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingOptions.swift
@@ -22,5 +22,7 @@ public struct JSONEncodingOptions {
   /// By default they are converted to JSON(lowerCamelCase) names.
   public var preserveProtoFieldNames: Bool = false
 
+  /// Wether to include proto field with default value
+  public var includeDefaultValue: Bool = false
   public init() {}
 }

--- a/Sources/SwiftProtobuf/JSONEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingOptions.swift
@@ -24,5 +24,6 @@ public struct JSONEncodingOptions {
 
   /// Wether to include proto field with default value
   public var includeDefaultValue: Bool = false
+    
   public init() {}
 }

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -331,6 +331,10 @@ internal struct JSONEncodingVisitor: Visitor {
   mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws {
     // JSON does not store extensions
   }
+    
+  mutating func shouldIncludeDefault() -> Bool {
+    return options.includeDefaultValue
+  }
 
   /// Helper function that throws an error if the field number could not be
   /// resolved.

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -331,8 +331,8 @@ internal struct JSONEncodingVisitor: Visitor {
   mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws {
     // JSON does not store extensions
   }
-    
-  mutating func shouldIncludeDefault() -> Bool {
+ 
+  func shouldIncludeDefault() -> Bool {
     return options.includeDefaultValue
   }
 

--- a/Sources/SwiftProtobuf/Visitor.swift
+++ b/Sources/SwiftProtobuf/Visitor.swift
@@ -443,6 +443,8 @@ public protocol Visitor {
 
   /// Called with the raw bytes that represent any unknown fields.
   mutating func visitUnknown(bytes: Data) throws
+    
+ func shouldIncludeDefault() -> Bool
 }
 
 /// Forwarding default implementations of some visitor methods, for convenience.
@@ -690,4 +692,8 @@ extension Visitor {
   public mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws {
     try fields.traverse(visitor: &self, start: start, end: end)
   }
+    
+    func shouldIncludeDefault()->Bool {
+        return false
+    }
 }

--- a/Sources/SwiftProtobuf/Visitor.swift
+++ b/Sources/SwiftProtobuf/Visitor.swift
@@ -693,7 +693,7 @@ extension Visitor {
     try fields.traverse(visitor: &self, start: start, end: end)
   }
     
-    func shouldIncludeDefault()->Bool {
+    func shouldIncludeDefault() -> Bool {
         return false
     }
 }

--- a/Sources/protoc-gen-swift/FieldGenerator.swift
+++ b/Sources/protoc-gen-swift/FieldGenerator.swift
@@ -51,6 +51,8 @@ protocol FieldGenerator {
   /// Generate any support needed to this field's value is initialized.
   /// The generated code should return false if it isn't set.
   func generateIsInitializedCheck(printer: inout CodePrinter)
+
+  func shouldGenerateIncludeDefault() -> Bool
 }
 
 /// Simple base class for FieldGenerators that also provides fieldMapNames.
@@ -92,5 +94,9 @@ class FieldGeneratorBase {
     precondition(!descriptor.isExtension)
     number = Int(descriptor.number)
     fieldDescriptor = descriptor
+  }
+
+  func shouldGenerateIncludeDefault() -> Bool {
+    return false
   }
 }

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -198,7 +198,7 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
 
         let conditional: String
         if isRepeated {  // Also covers maps
-            conditional = "!\(varName).isEmpty || shouldInlcudeDefault"
+            conditional = "!\(varName).isEmpty || shouldIncludeDefault"
         } else if hasFieldPresence {
             conditional = "let v = \(storedProperty)"
         } else {
@@ -207,13 +207,13 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
             assert(fieldDescriptor.file.syntax == .proto3)
             switch fieldDescriptor.type {
             case .string, .bytes:
-                conditional = ("!\(varName).isEmpty || shouldInlcudeDefault")
+                conditional = ("!\(varName).isEmpty || shouldIncludeDefault")
             default:
-                conditional = ("\(varName) != \(swiftDefaultValue) || shouldInlcudeDefault")
+                conditional = ("\(varName) != \(swiftDefaultValue) || shouldIncludeDefault")
             }
         }
 
-        p.print("if \(conditional) || shouldInlcudeDefault {\n")
+        p.print("if \(conditional) {\n")
         p.indent()
         p.print("try visitor.\(visitMethod)(\(traitsArg)value: \(varName), fieldNumber: \(number))\n")
         p.outdent()

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -198,7 +198,7 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
 
         let conditional: String
         if isRepeated {  // Also covers maps
-            conditional = "!\(varName).isEmpty"
+            conditional = "!\(varName).isEmpty || visitor.shouldIncludeDefault()"
         } else if hasFieldPresence {
             conditional = "let v = \(storedProperty)"
         } else {
@@ -207,13 +207,13 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
             assert(fieldDescriptor.file.syntax == .proto3)
             switch fieldDescriptor.type {
             case .string, .bytes:
-                conditional = ("!\(varName).isEmpty")
+                conditional = ("!\(varName).isEmpty || visitor.shouldIncludeDefault()")
             default:
-                conditional = ("\(varName) != \(swiftDefaultValue)")
+                conditional = ("\(varName) != \(swiftDefaultValue) || visitor.shouldIncludeDefault()")
             }
         }
 
-        p.print("if \(conditional) {\n")
+        p.print("if \(conditional) || visitor.shouldIncludeDefault() {\n")
         p.indent()
         p.print("try visitor.\(visitMethod)(\(traitsArg)value: \(varName), fieldNumber: \(number))\n")
         p.outdent()

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -198,7 +198,7 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
 
         let conditional: String
         if isRepeated {  // Also covers maps
-            conditional = "!\(varName).isEmpty || visitor.shouldIncludeDefault()"
+            conditional = "!\(varName).isEmpty || shouldInlcudeDefault"
         } else if hasFieldPresence {
             conditional = "let v = \(storedProperty)"
         } else {
@@ -207,9 +207,9 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
             assert(fieldDescriptor.file.syntax == .proto3)
             switch fieldDescriptor.type {
             case .string, .bytes:
-                conditional = ("!\(varName).isEmpty || visitor.shouldIncludeDefault()")
+                conditional = ("!\(varName).isEmpty || shouldInlcudeDefault")
             default:
-                conditional = ("\(varName) != \(swiftDefaultValue) || visitor.shouldIncludeDefault()")
+                conditional = ("\(varName) != \(swiftDefaultValue) || shouldInlcudeDefault")
             }
         }
 

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -213,7 +213,7 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
             }
         }
 
-        p.print("if \(conditional) || visitor.shouldIncludeDefault() {\n")
+        p.print("if \(conditional) || shouldInlcudeDefault {\n")
         p.indent()
         p.print("try visitor.\(visitMethod)(\(traitsArg)value: \(varName), fieldNumber: \(number))\n")
         p.outdent()

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -182,6 +182,11 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
         p.print("case \(number): try decoder.\(decoderMethod)(\(traitsArg)value: &\(storedProperty))\n")
     }
 
+    override func shouldGenerateIncludeDefault() -> Bool{
+        if isRepeated { return true}
+        return !hasFieldPresence
+    }
+
     func generateTraverse(printer p: inout CodePrinter) {
         let visitMethod: String
         let traitsArg: String

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -318,7 +318,6 @@ class MessageGenerator {
   private func generateTraverse(printer p: inout CodePrinter) {
     p.print("\(visibility)func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {\n")
     p.indent()
-    p.print("let shouldIncludeDefault = visitor.shouldIncludeDefault()\n")
     generateWithLifetimeExtension(printer: &p, throws: true) { p in
       if let storage = storage {
         storage.generatePreTraverse(printer: &p)
@@ -329,6 +328,13 @@ class MessageGenerator {
 
       var ranges = descriptor.extensionRanges.makeIterator()
       var nextRange = ranges.next()
+      var shouldGenerateInclude = false
+      for f in fieldsSortedByNumber {
+        shouldGenerateInclude = shouldGenerateInclude || f.shouldGenerateIncludeDefault()
+      }
+      if shouldGenerateInclude {
+        p.print("let shouldIncludeDefault = visitor.shouldIncludeDefault()\n")
+      }
       for f in fieldsSortedByNumber {
         while nextRange != nil && Int(nextRange!.start) < f.number {
           p.print("try visitor.\(visitExtensionsName)(fields: _protobuf_extensionFieldValues, start: \(nextRange!.start), end: \(nextRange!.end))\n")

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -318,6 +318,7 @@ class MessageGenerator {
   private func generateTraverse(printer p: inout CodePrinter) {
     p.print("\(visibility)func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {\n")
     p.indent()
+    p.print("let shouldIncludeDefault = visitor.shouldIncludeDefault()\n")
     generateWithLifetimeExtension(printer: &p, throws: true) { p in
       if let storage = storage {
         storage.generatePreTraverse(printer: &p)


### PR DESCRIPTION
https://github.com/apple/swift-protobuf/issues/861

See discussion in the ticket, this PR adds a new method in Visitor Protocol. 

```
  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
    let shouldIncludeDefault = visitor.shouldIncludeDefault()
    if !self.text.isEmpty || shouldIncludeDefault {
      try visitor.visitSingularStringField(value: self.text, fieldNumber: 1)
    }
    if self.action != .searchCancelEventActionInvalid || shouldIncludeDefault {
      try visitor.visitSingularEnumField(value: self.action, fieldNumber: 2)
    }
    if self.resultCount != 0  || shouldIncludeDefault {
      try visitor.visitSingularUInt32Field(value: self.resultCount, fieldNumber: 3)
    }
    try unknownFields.traverse(visitor: &visitor)
  }
```